### PR TITLE
Ensure `deno task dev` runs without permission requests

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "dev": "deno run --unstable-kv --watch main.ts"
+    "dev": "deno run --allow-net --unstable-kv --watch main.ts"
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@1",
@@ -8,9 +8,7 @@
   },
   "deploy": {
     "project": "a49db880-a1d0-4f2b-9576-4e23cbaae630",
-    "exclude": [
-      "**/node_modules"
-    ],
+    "exclude": ["**/node_modules"],
     "include": [],
     "entrypoint": "main.ts"
   }

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "dev": "deno run --watch main.ts"
+    "dev": "deno run --unstable-kv --watch main.ts"
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@1",


### PR DESCRIPTION
This just adds `--unstable-kv` which is necessary to run KV (while its still unstable) and `--allow-net` to allow listening on port 8000. Could narrow down the network permissions, but it seems fine for now. 