### PR TITLE
Use deno fmt as default formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.defaultFormatter": "denoland.vscode-deno"
+}


### PR DESCRIPTION
Small usability tweak to ensure `deno fmt` is used over most people's default `prettier` config when using vscode. 